### PR TITLE
hide ref_id from export

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,39 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: "[BUG] "
+labels: bug
+assignees: lorawoodford
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+_Optional, but include if helpful/relevant_
+**Desktop:**
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
+
+**Smartphone/Mobile:**
+ - Device: [e.g. iPhone6]
+ - OS: [e.g. iOS8.1]
+ - Browser [e.g. stock browser, safari]
+ - Version [e.g. 22]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: "[FEATURE]"
+labels: enhancement
+assignees: lorawoodford
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,23 @@
+## Description
+<!--- Describe your changes.  Why is this required?  What problem does it solve?  What functionality does it extend? -->
+
+## Related GitHub Issue
+<!--- Please link to GitHub Issue here: -->
+
+## Testing
+<!--- Please describe, in detail, how you tested your changes. -->
+
+## Screenshot(s):
+<!--- Optional screenshots of changes if relevant and helpful to reviewers -->
+
+## Checklist
+
+- [ ] ✔️ Have you assigned at least one reviewer?
+- [ ] 🔗 Have you referenced any issues this PR will close?
+- [ ] ⬇️ Have you merged the latest upstream changes into your branch? 
+- [ ] 🧪 Have you added tests to cover these changes?  If not, why:
+
+- [ ] 🤖 Have automated checks (if any) passed?  If not, please explain for the reviewer:
+
+- [ ] 📘 Have you updated/added any relevant readmes/comments in the codebase?
+- [ ] 📚 Have you updated/added any external documentation (e.g. Confluence)?

--- a/frontend/views/spreadsheet_bulk_updater/download_form.html.erb
+++ b/frontend/views/spreadsheet_bulk_updater/download_form.html.erb
@@ -38,7 +38,6 @@
           [
             ['update_select_level', 'archival_object.level'],
             ['update_select_component_id', 'archival_object.component_id'],
-            ['update_select_ref_id', 'archival_object.ref_id'],
             ['update_select_repository_processing_note', 'archival_object.repository_processing_note'],
             ['update_select_publish', 'archival_object.publish'],
             ['update_select_date', 'date._plural'],


### PR DESCRIPTION
Hides the "ref_id" option from the download spreadsheet form to address: https://github.com/Smithsonian/caas_aspace_refid/issues/15

Also adds some basic pr and issue templates to maintain consistency across our repos.

Closes #1 