### PR TITLE
[FEATURE] Reenable ref_id export in bulk update spreadsheet Smithsoni…

### DIFF
--- a/frontend/views/spreadsheet_bulk_updater/download_form.html.erb
+++ b/frontend/views/spreadsheet_bulk_updater/download_form.html.erb
@@ -38,6 +38,7 @@
           [
             ['update_select_level', 'archival_object.level'],
             ['update_select_component_id', 'archival_object.component_id'],
+            ['update_select_ref_id', 'archival_object.ref_id'],
             ['update_select_repository_processing_note', 'archival_object.repository_processing_note'],
             ['update_select_publish', 'archival_object.publish'],
             ['update_select_date', 'date._plural'],


### PR DESCRIPTION
…an/as_spreadsheet_bulk_updater#4

## Description
Update to accompany https://github.com/Smithsonian/caas_aspace_refid/pull/45

## Related GitHub Issue
Closes #4 

## Testing
N/A

## Screenshot(s):
<img width="342" alt="Screenshot 2025-04-15 at 1 27 59 PM" src="https://github.com/user-attachments/assets/0710f46d-b31a-4a42-a789-dbdaf3000ab5" />

## Checklist

- [ ] ✔️ Have you assigned at least one reviewer?
Minor change discussed on 4/15 standup, so skipping formal review.
- [x] 🔗 Have you referenced any issues this PR will close?
- [x] ⬇️ Have you merged the latest upstream changes into your branch? 
- [x] 🧪 Have you added tests to cover these changes?  If not, why:
No tests in this temporary fork
- [ ] 🤖 Have automated checks (if any) passed?  If not, please explain for the reviewer:
No tests in this temporary fork
- [x] 📘 Have you updated/added any relevant readmes/comments in the codebase?
- [x] 📚 Have you updated/added any external documentation (e.g. Confluence)?
